### PR TITLE
feat(conversation): add endpoint to assign conversations

### DIFF
--- a/back_end/src/infra/http/controllers/ConversationController.ts
+++ b/back_end/src/infra/http/controllers/ConversationController.ts
@@ -46,3 +46,60 @@ export const getConversationsRoute: FastifyPluginAsyncZod = async (server) => {
     }
   });
 };
+
+const assignBodySchema = z.object({
+  email: z.string().email({ message: "Invalid email address" }),
+});
+
+const assignParamsSchema = z.object({
+  conversationId: z.string(),
+});
+
+export const assignConversationRoute: FastifyPluginAsyncZod = async (server) => {
+  server.post('/conversation/:conversationId/assign', {
+    schema: {
+      tags: ['conversation'],
+      summary: 'Assign a conversation to an agent by email',
+      params: assignParamsSchema, 
+      body: assignBodySchema,     
+      response: {
+        200: z.object({
+          message: z.string(),
+        }),
+        500: errorResponseSchema,
+      }
+    },
+  }, async (request, reply) => {
+    if (!process.env.API_KEY) {
+      console.error('API_KEY is not defined in environment variables');
+      return reply.status(500).send({ error: 'API key is missing' });
+    }
+
+    const { conversationId } = request.params; 
+    const { email } = request.body;            
+
+    const options = {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${process.env.API_KEY}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ email })
+    };
+    
+    try {
+      const apiResponse = await fetch(`https://api.chatvolt.ai/conversations/${conversationId}/assign`, options);
+      
+      if (!apiResponse.ok) {
+        const errorData = await apiResponse.json();
+        console.error('Error from external API:', apiResponse.status, errorData);
+        return reply.status(500).send({ error: 'Failed to assign conversation' });
+      }
+      const data = await apiResponse.json();
+      return reply.status(200).send({message: "A"});
+    } catch (error) {
+      console.error('Error assigning conversation:', error);
+      return reply.status(500).send({ error: 'Failed to assign conversation' });
+    }
+  });
+};

--- a/back_end/src/infra/http/server.ts
+++ b/back_end/src/infra/http/server.ts
@@ -3,7 +3,7 @@ import cors from '@fastify/cors';
 import scalarAPIReference from '@scalar/fastify-api-reference'
 import { fastifySwagger } from '@fastify/swagger';
 import 'dotenv/config'
-import { getConversationsRoute } from './controllers/ConversationController';
+import { assignConversationRoute, getConversationsRoute } from './controllers/ConversationController';
 import { validatorCompiler, serializerCompiler, type ZodTypeProvider, jsonSchemaTransform } from 'fastify-type-provider-zod'
 
 const server = Fastify();
@@ -29,4 +29,5 @@ server.setValidatorCompiler(validatorCompiler)
 server.setSerializerCompiler(serializerCompiler)
 
 server.register(getConversationsRoute);
+server.register(assignConversationRoute);
 export const app = server;

--- a/back_end/tsconfig.json
+++ b/back_end/tsconfig.json
@@ -23,9 +23,11 @@
     "moduleResolution": "node",
     "baseUrl": "./",
     "paths": {
-      "@/": ["src/"],
+      "@/*": ["src/"]
     }
   },
-  "include": ["src/*/"],
+  "include": [
+    "src/**/*.ts" // Esta é a correção crucial. Inclui todos os arquivos .ts dentro de src
+  ],
   "exclude": ["node_modules", "dist", "tests"]
 }


### PR DESCRIPTION
This commit introduces the POST /conversation/:conversationId/assign route, which acts as a proxy to the official Chatvolt API.

It allows assigning a conversation to a specific agent by providing their email in the request body. Zod schemas have been added to validate the 'conversationId' from the URL parameters and the 'email' from the body, ensuring request integrity.